### PR TITLE
JOBILLA-1256 Refactor & cleanup DtoAbstract and TestCase

### DIFF
--- a/src/DtoAbstract.php
+++ b/src/DtoAbstract.php
@@ -122,9 +122,11 @@ abstract class DtoAbstract extends Collection
     }
 
     /**
+     * Init, populate and validate a DTO from model instance
+     *
      * @param Model $model
      *
-     * @return mixed
+     * @return DtoAbstract
      */
     public static function fromModel(Model $model): DtoAbstract
     {
@@ -137,6 +139,8 @@ abstract class DtoAbstract extends Collection
     }
 
     /**
+     * Init, populate and validate a Collection of DTO-s from a Collection of model instances
+     *
      * @param Model[]|Collection $models
      *
      * @return Collection|$self[]
@@ -149,7 +153,7 @@ abstract class DtoAbstract extends Collection
     }
 
     /**
-     * Populate DTO and sub-DTO-s from data array
+     * Init, populate and validate a DTO and sub-DTO-s from data array
      *
      * - Can be used in controllers, to fill from Request::all()
      * - Only sets values for keys that are predefined in DTO
@@ -218,7 +222,7 @@ abstract class DtoAbstract extends Collection
      *
      * Include list of failures for each field, in machine-parseable format.
      *
-     * @param $validator
+     * @param Validator $validator
      *
      * @throws ValidatorException
      */

--- a/src/Tests/DtoAbstractTest.php
+++ b/src/Tests/DtoAbstractTest.php
@@ -49,7 +49,7 @@ class DtoAbstractTest extends TestCase
 
     /**
      * @test
-     * @covers ::populateFromArray
+     * @covers ::fromArray
      * @covers ::populateSubtypeFromArray
      */
     public function populate_from_array_sets_correct_subtype()

--- a/src/Tests/TestCase.php
+++ b/src/Tests/TestCase.php
@@ -17,11 +17,6 @@ abstract class TestCase extends RootTestCase
     protected $filledKeys = [];
 
     /**
-     * @return DtoAbstract
-     */
-    abstract protected function dtoProvider(): DtoAbstract;
-
-    /**
      * @return Model
      */
     abstract protected function modelProvider();
@@ -31,16 +26,8 @@ abstract class TestCase extends RootTestCase
      */
     public function populates_from_model()
     {
-        $dto = $this->dtoProvider();
-        $dto->populateFromModel($this->modelProvider());
-
-        $this->assertFalse($dto->validate()->fails());
-
-        $array = $dto->toArray();
-
-        foreach ($this->filledKeys as $key) {
-            $this->assertNotNull($array[$key], "Key $key should not be null");
-        }
+        $dto = (static::DTO)::from($this->modelProvider());
+        $this->assertDtoFields($dto);
     }
 
     /**
@@ -48,18 +35,22 @@ abstract class TestCase extends RootTestCase
      */
     public function populates_from_array()
     {
-        $dto = $this->dtoProvider();
-        $dto->populateFromModel($this->modelProvider());
-        $array = $dto->toArray();
+        $inputArray = (static::DTO)::from($this->modelProvider())->toArray();
+        $dto        = (static::DTO)::from($inputArray);
 
-        $dto = $this->dtoProvider();
-        $dto->populateFromArray($array);
+        $this->assertSame($inputArray, $dto->toArray());
+        $this->assertDtoFields($dto);
+    }
 
+    /**
+     * @param DtoAbstract $dto
+     */
+    private function assertDtoFields(DtoAbstract $dto)
+    {
         $this->assertFalse($dto->validate()->fails());
-        $this->assertSame($array, $dto->toArray());
 
         foreach ($this->filledKeys as $key) {
-            $this->assertNotNull($array[$key]);
+            $this->assertNotNull($dto[$key], "Key $key should not be null");
         }
     }
 }


### PR DESCRIPTION
- Clean up DtoAbstract logic
- Refactor how DTO-s can be populated. 

For any type of source, should now call `MyDto::from($mySource);`, 
where `$mySource` can be one of:
- one model object
- Collection of model objects
- a plain data array
- or anything else (in which case empty Collection is returned)

After this, filling subtypes can be done via:

`$dto['mySubtype'] = MySubtype::from($parentModel->subModel)->toArray();`