### PR TITLE
JOBILLA-1547 Fix invalid interpretation of missing value in DtoAbs

### DIFF
--- a/src/DtoAbstract.php
+++ b/src/DtoAbstract.php
@@ -107,7 +107,7 @@ abstract class DtoAbstract extends Collection
     {
         collect(array_intersect_key($data, $this->toArray()))
             ->filter(function ($value) {
-                return $value !== null && !empty($value);
+                return !in_array($value, [null, ''], true);
             })
             ->map(function ($value, $key) {
                 if (is_array($value) && $this->getSubtype($key)) {


### PR DESCRIPTION
Populate from array is supposed to skip missing or empty values.
Previously, boolean false and 0 was skipped, which is invalid.
New implementation skips null and empty string values.